### PR TITLE
🚑 : IOS 및 사파리 로고 관련 UI 이슈 해결

### DIFF
--- a/src/components/blocks/Navigtaion.tsx
+++ b/src/components/blocks/Navigtaion.tsx
@@ -6,8 +6,8 @@ import TitleLogoIcon from '../molecules/icons/TitleLogoIcon'
 const Navigation = () => {
   return (
     <nav className="flex w-full justify-between">
-      <Link to="/">
-        <TitleLogoIcon className="h-[20px] w-fit cursor-pointer" />
+      <Link to="/" className="flex justify-start">
+        <TitleLogoIcon className="h-[20px] w-auto cursor-pointer" />
       </Link>
       <MenuHamberger />
     </nav>

--- a/src/hooks/useGetUser.ts
+++ b/src/hooks/useGetUser.ts
@@ -9,7 +9,7 @@ type UseQueryOption = Omit<
 >
 
 const useGetUser = (options?: UseQueryOption) => {
-  const token = getCookie('access-token')
+  const token = getCookie('accessToken')
 
   return useQuery<User, RequestError>('getUser', getUser, {
     ...options,


### PR DESCRIPTION
## 개요

- 어떤 기능을 처리했는지 작성 해주세요
- [x]  IOS 기기에서 로고의 width 값이 속성우선으로 되는 이슈 때문에 의도한 대로 보이지 않는 것 해결 하였습니다.

<img width="371" alt="image" src="https://user-images.githubusercontent.com/63512217/191734991-bd7152c7-de83-40eb-a748-7c1ae42f20ea.png">

- [x]  Cooke 값 변경에 따른 토큰 불러오는 코드 변경 하였습니다

